### PR TITLE
Change restart policy to always in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,6 @@ services:
       - ./.env:/home/node/app/.env:ro
     environment:
       - NODE_ENV=production
-    restart: unless-stopped
+    restart: always
     ports:
       - "172.17.0.1:4000:4000"


### PR DESCRIPTION
I noticed when we do a reboot of the host VM , it issues a `stop` to the docker service, and since `restart` isn't `always` it doesn't start up.  As well, @Hareet noticed we could make this improvement too! 