### PR TITLE
bump image version in compose x2

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   node:
     # upon code changes, increment version so image is rebuilt
-    image: medic-demo-account-slack-bot:1.2
+    image: medic-demo-account-slack-bot:1.2.1
     build:
       context: .
     volumes:


### PR DESCRIPTION
oops! I forgot whenever we make a code, like we did in [15](https://github.com/medic/demo-account-slack-bot/pull/15/changes), we have to compliment it with a compose version change or else the image won't rebuild with the new code.

this PR does that